### PR TITLE
Streamline IoT Docker Setup and Configuration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Based on: https://github.com/Miceuz/docker-compose-mosquitto-influxdb-telegraf-g
 
 ## Prerequisites
 
-1. A DigitalOcean account ([Log in](https://cloud.digitalocean.com/login))
-2. doctl CLI ([tutorial](https://docs.digitalocean.com/reference/doctl/how-to/install/))
+1. A DigitalOcean account - [Sign up here](https://cloud.digitalocean.com)
+2. doctl CLI - [Installation guide](https://docs.digitalocean.com)
 
-# Quick / Easy version
+## Quick / Easy version
 
-1. Clone this repo `git clone https://github.com/DO-Solutions/iot-docker`
-2. Enter the directory `cd iot-docker`
-3. Deploy the Droplet
+1. Clone this repo: `git clone https://github.com/DO-Solutions/iot-docker`
+2. Enter the directory: `cd iot-docker`
+3. Deploy the Droplet using the following command:
 
 ```bash
 doctl compute droplet create iot-droplet \
@@ -53,19 +53,20 @@ doctl compute droplet create iot-droplet \
 --user-data-file cloudinit.yml
 ```
 
-To check on your deployment SSH into your Droplet and run `tail -f /var/log/cloud-init-output.log`
-
-To check the running services run `cd /iot-docker && docker ps`
-
-To shutdown the whole thing `cd /iot-docker && docker-compose down`
+4. To check on your deployment SSH into your Droplet and run `tail -f /var/log/cloud-init-output.log`
+5. To check the running services run `cd /iot-docker && docker ps`
+6. To shutdown the whole thing `cd /iot-docker && docker-compose down`
 
 ## Test your setup
 
-Post some messages into your Mosquitto so you'll be able to see some data in Grafana already:
+1. 1. Post messages into Mosquitto to see data in Grafana:
 
 ```bash
 sudo docker container exec mosquitto mosquitto_pub -t 'paper_wifi/test/' -m '{"humidity":21, "temperature":21, "battery_voltage_mv":3000}'
 ```
+
+2. Access Grafana at `http://<your-server-ip>:3000`. Username: `admin`, Password: `/iot-docker/grafanapassword.txt`.
+3. Explore InfluxDB at `http://<your-server-ip>:8086`. Credentials in `docker-compose.yml`.
 
 ### Grafana
 
@@ -88,7 +89,8 @@ Username and password are found in `docker-compose.yml`
 
 ### Mosquitto
 
-Mosquitto is configured to allow anonymous connections and posting of messages
+- Allows anonymous connections.
+- Configured to listen on port 1883.
 
 ```yaml
 listener 1883
@@ -97,19 +99,19 @@ allow_anonymous true
 
 ### InfluxDB
 
-The configuration is fully in `docker-compose.yml`.
+- Configuration details are available in `docker-compose.yml`.
 
 ### Telegraf
 
-Telegraf is responsible for piping mqtt messages to influxdb. It is set up to listen for topic `paper_wifi/test`. You can alter this configuration according to your needs, check the official documentation on how to do that.
+- Set up to pipe MQTT messages to InfluxDB.
+- Listens for topic `paper_wifi/test`.
+- Configuration can be modified as per the official documentation.
 
 ### Grafana data source
 
-Grafana is provisioned with a default data source pointing to the InfluxDB instance installed in this same compose. The configuration file is `grafana-provisioning/datasources/automatic.yml`.
-
-### Grafana dashboard
-
-Default Grafana dashboard is also set up in this directory: `grafana-provisioning/dashboards`
+- Comes with a default data source pointing to InfluxDB.
+- Configuration: `grafana-provisioning/datasources/automatic.yml`.
+- Default dashboard setup in `grafana-provisioning/dashboards`.
 
 
 <!-- CONTACT -->

--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ Based on: https://github.com/Miceuz/docker-compose-mosquitto-influxdb-telegraf-g
 1. A DigitalOcean account - [Sign up here](https://cloud.digitalocean.com)
 2. doctl CLI - [Installation guide](https://docs.digitalocean.com)
 
-## Quick / Easy version
+## Running on an Existing Droplet
+
+Instead of manually deploying a new Droplet, you can run `scripts/install.sh` on an existing DigitalOcean Droplet to set up the environment. This script automates the installation process.
+
+
+## Deploying a New Droplet
+
+To deploy a new Droplet with the necessary software installed:
 
 1. Clone this repo: `git clone https://github.com/DO-Solutions/iot-docker`
 2. Enter the directory: `cd iot-docker`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ doctl compute droplet create iot-droplet \
 
 ## Test your setup
 
-1. 1. Post messages into Mosquitto to see data in Grafana:
+1. Post messages into Mosquitto to see data in Grafana:
 
 ```bash
 sudo docker container exec mosquitto mosquitto_pub -t 'paper_wifi/test/' -m '{"humidity":21, "temperature":21, "battery_voltage_mv":3000}'

--- a/scripts/doctl-with-user-data.sh
+++ b/scripts/doctl-with-user-data.sh
@@ -1,19 +1,35 @@
 doctl compute droplet create iot-droplet --size s-2vcpu-4gb --image ubuntu-23-10-x64 --region lon1 --enable-backups --user-data "#cloud-config
 
 runcmd:
+  # Update package lists and upgrade all packages
   - apt-get update && apt-get upgrade
-  - curl -fsSL https://get.docker.com -o get-docker.sh
-  - sh get-docker.sh
-  - apt-get update && apt-get install -y docker-compose git
-  - git clone https://github.com/jkpe/docker-compose-mosquitto-influxdb-telegraf-grafana
-  - cd docker-compose-mosquitto-influxdb-telegraf-grafana
-  - export INFLUXDB_ADMIN_TOKEN=$(openssl rand -hex 24)
-  - export INFLUXDB_USERNAME=$(openssl rand -hex 8)
-  - export INFLUXDB_PASSWORD=$(openssl rand -hex 8)
-  - sed -i 's/DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=/DOCKER_INFLUXDB_INIT_ADMIN_TOKEN='$INFLUXDB_ADMIN_TOKEN'/g' docker-compose.yml
-  - sed -i 's/DOCKER_INFLUXDB_INIT_USERNAME=/DOCKER_INFLUXDB_INIT_USERNAME='$INFLUXDB_USERNAME'/g' docker-compose.yml
-  - sed -i 's/DOCKER_INFLUXDB_INIT_PASSWORD=/DOCKER_INFLUXDB_INIT_PASSWORD='$INFLUXDB_PASSWORD'/g' docker-compose.yml
-  - sed -i 's/token = \"\"/token = \"'$INFLUXDB_ADMIN_TOKEN'\"/g' telegraf.conf
-  - sed -i 's/token: token_here/token: '$INFLUXDB_ADMIN_TOKEN'/g' grafana-provisioning/datasources/automatic.yml
 
+  # Download Docker installation script
+  - curl -fsSL https://get.docker.com -o get-docker.sh
+
+  # Execute the Docker installation script
+  - sh get-docker.sh
+
+  # Update package lists and install docker-compose and git
+  - apt-get update && apt-get install -y docker-compose git
+
+  # Clone the iot-docker repository from GitHub
+  - git clone https://github.com/DO-Solutions/iot-docker
+
+  # Change directory to iot-docker and checkout the dev branch
+  - cd iot-docker && git checkout main 
+
+  # Set environment variables with random values and modify docker-compose.yml and telegraf.conf
+  # with these values for InfluxDB and Grafana configuration
+  - |
+    export INFLUXDB_ADMIN_TOKEN=$(openssl rand -hex 24) && export INFLUXDB_USERNAME=$(openssl rand -hex 16) && export INFLUXDB_PASSWORD=$(openssl rand -hex 16) && sed -i 's/DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=/DOCKER_INFLUXDB_INIT_ADMIN_TOKEN='$INFLUXDB_ADMIN_TOKEN'/g' docker-compose.yml && sed -i 's/DOCKER_INFLUXDB_INIT_USERNAME=/DOCKER_INFLUXDB_INIT_USERNAME='$INFLUXDB_USERNAME'/g' docker-compose.yml && sed -i 's/DOCKER_INFLUXDB_INIT_PASSWORD=/DOCKER_INFLUXDB_INIT_PASSWORD='$INFLUXDB_PASSWORD'/g' docker-compose.yml && sed -i 's/token = \"\"/token = \"'$INFLUXDB_ADMIN_TOKEN'\"/g' telegraf.conf && echo '      token: '"$INFLUXDB_ADMIN_TOKEN" >> grafana-provisioning/datasources/automatic.yml
+  
+  # Run docker-compose in detached mode
   - docker-compose up -d
+
+  # Sleep for 10 seconds to allow InfluxDB and Grafana to start, securely generate Grafana admin password and reset it
+
+  - |
+    sleep 10
+    export GRAFANA_PASSWORD=$(openssl rand -hex 16) && docker exec grafana grafana-cli admin reset-admin-password "$GRAFANA_PASSWORD"
+    echo $GRAFANA_PASSWORD > /iot-docker/grafanapassword.txt


### PR DESCRIPTION
1. Changed the descriptions for the DigitalOcean account and doctl CLI.
2. Condensed the deployment instructions for new Droplets
3. Modified instructions for running install.sh on an existing droplet
4. Revised the test setup instructions, specifically for Mosquitto and Grafana.